### PR TITLE
Get rid of Autoprefixer warning

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   plugins: {
-    autoprefixer: { browsers: ['> 2%'] }
+    autoprefixer: { overrideBrowserslist: ['> 2%'] }
   }
 };


### PR DESCRIPTION
Get rid of the warning:

```
warn
  Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.

  Using browsers option can cause errors. Browserslist config can
  be used for Babel, Autoprefixer, postcss-normalize and other tools.

  If you really need to use option, rename it to overrideBrowserslist.

  Learn more at:
  https://github.com/browserslist/browserslist#readme
  https://twitter.com/browserslist
```